### PR TITLE
DM-11004: Update based on build-stack-docs tool implementation

### DIFF
--- a/_docs-as-code.rst
+++ b/_docs-as-code.rst
@@ -47,6 +47,7 @@ A package provides two types of content:
 2. **Documentation for the package itself** such as ``afw``.
    This documentation concerns the Git repository itself and may provide developer documentation that is not oriented around Python modules.
    In fact, some packages, like ``afwdata`` or ``verify_metrics``, do not have any APIs and are entirely documented through this type of documentation.
+   We describe this content in :ref:`package-type`.
 
 Documentation of these two types are packaged into directories inside a package's ``doc/`` directory.
 For example, the ``afw`` package (which provides several Python modules) has documentation arranged like this::

--- a/_docs-as-code.rst
+++ b/_docs-as-code.rst
@@ -4,54 +4,169 @@ Documentation as code
 =====================
 
 The Science Pipelines documentation uses a *documentation-as-code* architecture.
-Documentation is stored and versioned in pipelines package repositories, and built by DM's standard continuous integration system with Sphinx_ into a static HTML site that is published to the web with `LSST the Docs`_.
-This section outlines the basic technical design of the Science Pipelines documentation.
+Documentation is stored and versioned in pipelines package repositories and built by DM's standard continuous integration system with Sphinx_ into a static HTML site that is published to the web with `LSST the Docs`_.
+
+This section outlines the basic technical design of the Science Pipelines documentation, including the layout of documentation in packages, and the system for linking package documentation into the root pipelines_lsst_io_ project.
+
+.. _main-repo:
+
+The pipelines_lsst_io repository
+--------------------------------
+
+The main Git repository for the Science Pipelines documentation is https://github.com/lsst/pipelines_lsst_io.
+This repository provides the main Sphinx_ project structure that is ultimately built when we deploy a new version of the Science Pipelines documentation.
+pipelines_lsst_io_ contains some content, namely:
+
+- The :ref:`homepage <homepage-design>`.
+- Getting-started tutorials and overviews.
+- Installation documentation.
+- Release notes and other project-wide documentation.
+- Homepages for the :ref:`processing topics <processing-topic-type>`.
+- Homepages for the :ref:`framework topics <framework-type>`.
+
+Most content, however, is stored in the Git repositories of individual packages and linked into the pipelines_lsst_io_ project at build time, as described in the following section.
+
+pipelines_lsst_io_ is an EUPS package itself and includes a ``ups/pipelines_lsst_io.table`` file.
+We use the table file to manage the list of packages that the Science Pipelines documentation project covers.
+By using the EUPS :command:`setup` command, the documentation build system can activate the correct set and versions of packages to build the Science Pipelines documentation.
 
 .. _docs-in-packages:
 
-Documentation in packages
--------------------------
+Organization of documentation in packages
+-----------------------------------------
 
-Each EUPS-managed LSST Science Pipelines package contains a ``doc/`` directory.
-All documentation specific to that package is contained within the ``doc/`` directory.
-A minimal ``doc/`` directory looks like::
+Each EUPS-managed LSST Science Pipelines package includes a ``doc/`` directory that contains documentation specific to that package.
+The arrangement of documentation *within* the ``doc/`` directory is motivated by the need to have package documentation mesh into the root ``pipelines_lsst_io`` project.
+
+A package provides two types of content:
+
+1. **Documentation for Python modules,** such as ``lsst.afw.table``.
+   This documentation content is oriented towards the code base, APIs, and its usage.
+   The bulk of Science Pipelines documentation is organized around Python modules.
+   We describe this content further in :ref:`module-type`.
+2. **Documentation for the package itself** such as ``afw``.
+   This documentation concerns the Git repository itself and may provide developer documentation that is not oriented around Python modules.
+   In fact, some packages, like ``afwdata`` or ``verify_metrics``, do not have any APIs and are entirely documented through this type of documentation.
+
+Documentation of these two types are packaged into directories inside a package's ``doc/`` directory.
+For example, the ``afw`` package (which provides several Python modules) has documentation arranged like this::
 
    doc/
      index.rst
-     tasks/
+     manifest.yaml
+     conf.py
      _static/
-
-Here, ``index.rst`` is a reStructuredText document we refer to as a :ref:`module topic <module-type>`, described later.
-The ``tasks/`` directory hosts :ref:`task topic pages <task-type>` for any pipeline tasks implemented in that module.
-The ``_static/`` directory is a space for non-reStructuredText content that is copied verbatim to the built site.
-
-Most Science Pipelines packages host a single :ref:`module <module-type>`, but there are exceptions like ``afw``.
-In this case, there is an additional level of directories::
-
-   doc/
-     index.rst
-     cameraGeom/
+       afw/
+         .. static content downloads
+     afw/
        index.rst
-       tasks/
-       _static/
-     coord/
-     detection/
-     display/
-     fits/
-     geom/
-     gpu/
-     image/
-     math/
-     table/
+       .. additional content
+     lsst.afw.cameraGeom/
+       index.rst
+       ..
+     lsst.afw.coord/
+       index.rst
+       ..
+     lsst.afw.detection/
+       index.rst
+       ..
+     lsst.afw.display/
+       index.rst
+       ..
+     lsst.afw.fits/
+       index.rst
+       ..
+     lsst.afw.geom/
+       index.rst
+       ..
+     lsst.afw.gpu/
+       index.rst
+       ..
+     lsst.afw.image/
+       index.rst
+       ..
+     lsst.afw.math/
+       index.rst
+       ..
+     lsst.afw.table/
+       index.rst
+       ..
 
-Each ``afw`` module subdirectory contains the ``index.rst``, ``tasks/`` and ``_static/`` structure.
-The root ``doc/index.rst`` file is a minimal file containing a `toctree`_ that is only used for local, single package documentation builds.
+Package-oriented documentation is contained in a directory named after the package/Git repository itself.
+For ``afw``, this is the ``doc/afw/`` directory.
+
+Each module's documentation is contained in a directory named after the Python namespace of the module itself.
+For example, ``doc/lsst.afw.cameraGeom``.
+
+The ``_static/afw/`` directory hosts static files for the package's documentation.
+In Sphinx, "static" files are directly copied to the output built without intermediate processing.
+These could be PDFs or tarball downloads.
+This static content is stored in a ``_static/`` directory.
+So that static content from all packages can be integrated, each package must store static content in a sub-directory of the ``_static`` directory, such as ``_static/afw``.
+
+Each package also has ``doc/conf.py`` and ``doc/index.rst`` files, these facilitate :ref:`single-package development builds <per-package-builds>`.
+
+Finally, the ``doc/manifest.yaml`` file facilitates integrated documentation builds, as described in the :ref:`next section <integrated-build>`.
 
 .. note::
 
    The ``doc/`` directory was already used by the previous Doxygen-based documentation build system.
    However, during the transition from Doxygen to Sphinx-based builds, we do not expect any conflicts since content for the two system reside in non-overlapping files (``.dox`` versus ``.rst`` files for Doxygen and Sphinx, respectively).
    It should be possible to continue to build a Doxygen version of the documentation while the new Sphinx site is being prepared.
+
+.. _integrated-build:
+
+Integrated documentation: linking package documenation into the pipelines_lsst_io repository
+--------------------------------------------------------------------------------------------
+
+When pipelines_lsst_io_ is built, the package, module, and ``_static`` documentation directories of each package are linked into the cloned pipelines_lsst_io_ repository::
+
+   pipelines_lsst_io/
+      index.rst
+      ..
+      modules/
+        lsst.afw.cameraGeom/ -> link to /afw/doc/lsst.afw.cameraGeom/
+        ..
+      packages/
+        afw/ -> link to /afw/doc/afw/
+        ..
+      _static
+        afw/ -> link to /afw/doc/_static/afw
+        ..
+
+Module documentation directories are symlinked into pipelines_lsst_io_\ ’s ``modules/`` directory.
+Likewise, package documentation directories are symlinked into pipelines_lsst_io_\ ’s ``packages/`` directory. With all documentation content directories linked  into the pipelines_lsst_io_ directory, Sphinx is able to build the LSST Science Pipelines documentation if it were a unified project.
+
+Packages declare their module, package, and ``_static`` documentation directories with their own ``doc/manifest.yaml`` files.
+As an example, the ``doc/manifest.yaml`` file included in ``afw`` may look like this:
+
+.. code-block:: yaml
+
+   # Name of the package and also name of the package doc directory
+   package: "afw"
+
+   # Names of module doc directories;
+   # same as Python namespaces.
+   modules:
+     - "lsst.afw.cameraGeom"
+     - "lsst.afw.coord"
+     - "lsst.afw.detection"
+     - "lsst.afw.display"
+     - "lsst.afw.fits"
+     - "lsst.afw.geom"
+     - "lsst.afw.gpu"
+     - "lsst.afw.image"
+     - "lsst.afw.math"
+     - "lsst.afw.table"
+
+   # Names of static content directory
+   # Usually just one directory
+   statics:
+     - "_static/afw"
+
+The tool responsible for linking package documentation and running the Sphinx build is ``build-stack-docs``, included in the documenteer_ project.
+
+.. _per-package-builds:
 
 Per-package documentation builds
 --------------------------------
@@ -74,23 +189,3 @@ Instead, Sphinx configuration is centrally managed in SQuaRE's documenteer_ pack
    The single package documentation builds omit content from related packages, but will generate warnings about links to non-existent content.
    This is an acceptable trade-off for a development environment.
    In the continuous integration environment, where all documentation content is available, documentation builds can be configured to fail on broken links.
-
-Integrated documentation: the pipelines_lsst_io repository
-----------------------------------------------------------
-
-Besides documentation embedded in Science Pipelines packages, there is a core documentation repository: https://github.com/lsst/pipelines_lsst_io.
-This repository hosts higher-level documentation that crosses modules, including: installation guides, release notes, getting-started tutorials, processing and framework documentation.
-
-When pipelines_lsst_io_ is built, the ``doc/`` directories of each package is linked into the cloned pipelines_lsst_io_ repository::
-
-   pipelines_lsst_io/
-      index.rst
-      _static
-      ...
-      afw/ -> linked or copied from afw/doc/
-      pipe_base -> linked or copied from pipe_base/doc/
-
-With these linked package ``doc`` directories, the Sphinx build for ``pipelines_lsst_io`` is able to build all documentation simultaneously, and resolve all links within the project.
-
-The `LTD Mason`_ tool (see SQR-006_) was designed to make the package documentation links, assuming that lsstsw was being used (as it is in the Jenkins environment).
-However, it may be more appropriate to make `pipelines_lsst_io`_ agnostic of lsstsw, which implies that `pipelines_lsst_io`_ should itself be an EUPS-managed package, and that its build logic should also be hosted in ``sconsUtils``.

--- a/_homepage-view.rst
+++ b/_homepage-view.rst
@@ -103,9 +103,20 @@ Each item is a link to a corresponding :ref:`framework topic <framework-type>`.
 Modules section
 ---------------
 
-The final section of the homepage is a comprehensive listing of modules in the LSST Science Pipelines.
+This section of the homepage is a comprehensive listing of modules in the LSST Science Pipelines.
 Each item is a link to a corresponding :ref:`module topic <module-type>`.
 This listing will be heavily used by developers seeking API references for the modules they are using on a day-to-day basis.
 
 These module topics are :ref:`imported from the doc/ directories <docs-in-packages>` of each Science Pipelines EUPS package.
 The homepage's module listing can be automatically compiled in a custom `reStructuredText directive`_.
+
+.. _homepage-packages:
+
+Packages section
+----------------
+
+The final section of the homepage is a comprehensive listing of EUPS packages in the LSST Science Pipelines.
+Each item is a link to a corresponding :ref:`package topic <package-type>`.
+This package documentation is useful for developers who are working with Git repositories and individual EUPS packages in the LSST Science Pipelines.
+
+Like modules, these package topics are :ref:`provided by the packages themselves <docs-in-packages>`.

--- a/_module-topic.rst
+++ b/_module-topic.rst
@@ -14,7 +14,6 @@ The module topic type consists of the following components:
 - :ref:`Tasks <module-tasks>`.
 - :ref:`Python API reference <module-api>`.
 - :ref:`C++ API reference <module-api>`.
-- :ref:`Packaging <module-packaging>`.
 - :ref:`Related documentation <module-related-docs>`.
 
 .. _fig-module-mockup:
@@ -85,22 +84,6 @@ Python and C++ API reference
 These sections list and link to reference pages for all Python and C++ API objects.
 Individual functions and classes are documented on separate pages.
 See :ref:`api-ref` for a discussion of API reference pages.
-
-.. _module-packaging:
-
-Packaging
----------
-
-Modules exist inside EUPS packages.
-This section is designed to help a user understand how to access a module, and understand how this module's package relates to other packages in the Science Pipelines documentation by:
-
-- Stating what package a module is part of.
-- Linking to that package's GitHub repository.
-- Stating what top-level packages include this module's package. This will help readers understand what package to install.
-- Stating what packages depend on this module's package, distinguishing between direct and in-direct dependencies. This will help developers.
-- Stating what packages in the LSST Stack dependent on this package. Again, this will primarily help developers.
-
-The package dependencies can be expressed as both lists and graph diagrams.
 
 .. _module-related-docs:
 

--- a/_package-topic.rst
+++ b/_package-topic.rst
@@ -1,0 +1,20 @@
+.. _package-type:
+
+Package topic type
+==================
+
+The package topic type documents individual stack packages (Git repositories).
+
+The topic type consists of the following components:
+
+- EUPS package name.
+- Description.
+- Git repository URL
+- JIRA component for issue reporting.
+- List of Python modules (linking to :ref:`module topics <module-type>`).
+- User and developer documentation appropriate for the package (for example, the procedure for updating datasets in a test data repository).
+- EUPS dependencies (computed both downstream and upstream).
+
+Most documentation provided by a package is included in :ref:`module topics <module-type>`.
+The package topic type, though, provides a documentation platform the package itself.
+Some packages may be documented only through the package topic type if they do not include Python APIs (such as data packages, or vendored third-party packages).

--- a/index.rst
+++ b/index.rst
@@ -14,5 +14,6 @@
 .. include:: _framework-topic.rst
 .. include:: _module-topic.rst
 .. include:: _task-topic.rst
+.. include:: _package-topic.rst
 .. include:: _api-ref.rst
 .. include:: _links.rst


### PR DESCRIPTION
This updates the documentation design based on implementation developments with the build tool (see also https://github.com/lsst-sqre/documenteer/pull/14).

- There is now a `doc/manifest.yaml` file that declares what documentation directories are included in a package and helps to create links.
- Introduces a new package topic type so that the packages/git repositories can be documented clearly. Previously package documentation was being conflated with module (python API) documentation topics, but this isn't a great fit — especially for data only packages, or packages with multiple modules.

See https://dmtn-030.lsst.io/v/DM-11004